### PR TITLE
chore: update to node16

### DIFF
--- a/src/welcome/action.yml
+++ b/src/welcome/action.yml
@@ -16,5 +16,5 @@ inputs:
     description: 'Append issue and pull request message with this message'
     default: ''
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
-> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: EddieHubCommunity/gh-action-community https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions
